### PR TITLE
Include remark script statically in compiled HTML.

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -52,12 +52,16 @@ module.exports = function (argv, md) {
 	var style = fs.readFileSync(argv.style);
 	// Load script
 	var script = argv.script ? fs.readFileSync(argv.script) : '';
+	// Load remark source code.
+	var remarkPath = require.resolve('remark/out/remark');
+	var remarkSource = fs.readFileSync(remarkPath);
 	// Compile template and pipe it out.
 	var rendered = mustache.render(fs.readFileSync(argv.template, 'utf8'), {
 		content: content,
 		style: style,
 		title: title,
-		script: script
+		script: script,
+		remarkSource: remarkSource
 	});
 
 	// Output

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 		"marked": "^0.3.2",
 		"marked-to-md": "1.0.x",
 		"mustache": "2.1.x",
-		"optimist": "~0.3.4"
+		"optimist": "~0.3.4",
+		"remark": "git://github.com/gnab/remark.git#v0.13.0"
 	},
 	"devDependencies": {
 		"tap-colorize": "^1.2.0",

--- a/template/template.html
+++ b/template/template.html
@@ -11,7 +11,7 @@
 		<textarea id="source">
 {{{content}}}
 		</textarea>
-		<script src="http://gnab.github.io/remark/downloads/remark-latest.min.js"></script>
+		<script>{{{remarkSource}}}</script>
 		<script>
 			var slideshow = remark.create();
 		</script>


### PR DESCRIPTION
This allows the slideshow to be run without an internet connection and greatly shortens the [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) before remark is able to render the slides.

It also helps insulate markdown-to-slides from unexpected changes in the remark project (hosting the file at a different URL, backwards-incompatible changes in a new release, etc).
