### PR TITLE
Edit protocol http to https

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -52,7 +52,7 @@ module.exports = function (argv, md) {
 	var style = fs.readFileSync(argv.style);
 	// Load script
 	var script = argv.script ? fs.readFileSync(argv.script) : '';
-	var remarkSource = '<script src="http://gnab.github.io/remark/downloads/remark-latest.min.js"></script>';
+	var remarkSource = '<script src="https://gnab.github.io/remark/downloads/remark-latest.min.js"></script>';
 	if (argv['include-remark']) {
 		// Load remark source code.
 		var remarkPath = require.resolve('remark/out/remark');

--- a/test/test.html
+++ b/test/test.html
@@ -164,7 +164,7 @@ class: center, middle, title
 ## The last slide
 
 		</textarea>
-		<script src="http://gnab.github.io/remark/downloads/remark-latest.min.js"></script>
+		<script src="https://gnab.github.io/remark/downloads/remark-latest.min.js"></script>
 		<script>
 			var slideshow = remark.create();
 		</script>


### PR DESCRIPTION
I could not use 'markdown-to-slides' in gh-pages, becaouse the tool is still using http-protocol for calling ibrary.
